### PR TITLE
Implement basic OpenGL renderer

### DIFF
--- a/origo3d/rendering/renderer.py
+++ b/origo3d/rendering/renderer.py
@@ -1,22 +1,75 @@
-"""Minimal rendering context using moderngl."""
+"""Простейший рендерер на базе :mod:`moderngl`.
+
+На данном этапе используется минимальный набор функций:
+* инициализация контекста OpenGL,
+* компиляция базовых вершинного и фрагментного шейдеров,
+* вывод на экран тестового треугольника.
+"""
 
 from __future__ import annotations
 
 from typing import Tuple
 
+import logging
+import numpy as np
+
 import moderngl
+
+from origo3d.shaders import FRAGMENT_SHADER_SOURCE, VERTEX_SHADER_SOURCE
 
 
 class Renderer:
-    """Create a rendering context and clear the screen."""
+    """Создаёт контекст рендера и выводит тестовый треугольник."""
 
     def __init__(self) -> None:
-        # ``moderngl.create_context`` uses the active OpenGL context
-        self.ctx = moderngl.create_context()
+        self.logger = logging.getLogger(__name__)
+        try:
+            # ``moderngl.create_context`` использует активный OpenGL-контекст
+            self.ctx = moderngl.create_context()
+        except Exception:  # pragma: no cover - зависит от среды
+            # В тестах контекст окна отсутствует, поэтому создаём автономный
+            self.logger.info("Standalone EGL context")
+            self.ctx = moderngl.create_standalone_context(backend="egl")
+
         self.clear_color: Tuple[float, float, float, float] = (0.1, 0.1, 0.1, 1.0)
 
+        # Компиляция простейших шейдеров
+        self.program = self.ctx.program(
+            vertex_shader=VERTEX_SHADER_SOURCE,
+            fragment_shader=FRAGMENT_SHADER_SOURCE,
+        )
+        self.logger.info("Shaders compiled successfully")
+
+        # Геометрия треугольника: XY + RGB
+        vertices = np.array(
+            [
+                -0.6,
+                -0.6,
+                1.0,
+                0.0,
+                0.0,
+                0.6,
+                -0.6,
+                0.0,
+                1.0,
+                0.0,
+                0.0,
+                0.6,
+                0.0,
+                0.0,
+                1.0,
+            ],
+            dtype="f4",
+        )
+        self.vbo = self.ctx.buffer(vertices.tobytes())
+        self.vao = self.ctx.vertex_array(
+            self.program,
+            [(self.vbo, "2f 3f", "in_position", "in_color")],
+        )
+
     def render_frame(self) -> None:
-        """Clear the screen with the configured color."""
+        """Очистить экран и нарисовать тестовый треугольник."""
         r, g, b, a = self.clear_color
         self.ctx.clear(r, g, b, a)
+        self.vao.render(moderngl.TRIANGLES)
 

--- a/origo3d/shaders/__init__.py
+++ b/origo3d/shaders/__init__.py
@@ -1,0 +1,22 @@
+"""Простейшие шейдеры для тестового рендера."""
+
+VERTEX_SHADER_SOURCE = """
+#version 330
+in vec2 in_position;
+in vec3 in_color;
+out vec3 v_color;
+void main() {
+    gl_Position = vec4(in_position, 0.0, 1.0);
+    v_color = in_color;
+}
+"""
+
+FRAGMENT_SHADER_SOURCE = """
+#version 330
+in vec3 v_color;
+out vec4 fragColor;
+void main() {
+    fragColor = vec4(v_color, 1.0);
+}
+"""
+

--- a/tests/test_renderer.py
+++ b/tests/test_renderer.py
@@ -1,0 +1,11 @@
+"""Tests for the rendering subsystem."""
+
+from origo3d.rendering.renderer import Renderer
+
+
+def test_renderer_initializes():
+    renderer = Renderer()
+    # Контекст должен быть создан, а программа скомпилирована
+    assert renderer.program is not None
+    renderer.render_frame()
+


### PR DESCRIPTION
## Summary
- завершить работу подсистемы рендеринга, инициализировав контекст OpenGL
- добавить простые источники вершинных/фрагментных шейдеров
- визуализировать цветной треугольник в каждом кадре
- провести регрессионный тест для инициализации средства рендеринга

## Testing
- `pytest -q`
