### PR TITLE
Добавлены обучаемые модели NPC

### DIFF
--- a/origo3d/ai/ml/__init__.py
+++ b/origo3d/ai/ml/__init__.py
@@ -1,0 +1,6 @@
+"""Модули для обучения поведения NPC."""
+
+from .qlearning_npc import QLearningNPC
+from .logistic_policy import LogisticPolicyNPC
+
+__all__ = ["QLearningNPC", "LogisticPolicyNPC"]

--- a/origo3d/ai/ml/logistic_policy.py
+++ b/origo3d/ai/ml/logistic_policy.py
@@ -1,0 +1,34 @@
+"""Простейшая стохастическая политика на основе логистической регрессии."""
+
+from __future__ import annotations
+
+from typing import Iterable
+
+import numpy as np
+
+
+class LogisticPolicyNPC:
+    """NPC, выбирающий действия при помощи мультиклассовой логистической регрессии."""
+
+    def __init__(self, state_dim: int, num_actions: int, lr: float = 0.1) -> None:
+        self.W = np.zeros((state_dim, num_actions))
+        self.lr = lr
+        self.num_actions = num_actions
+
+    def _softmax(self, z: np.ndarray) -> np.ndarray:
+        e = np.exp(z - np.max(z))
+        return e / e.sum()
+
+    def choose_action(self, state: Iterable[float]) -> int:
+        """Вернуть индекс выбранного действия."""
+        state_vec = np.asarray(state)
+        probs = self._softmax(state_vec @ self.W)
+        return int(np.random.choice(self.num_actions, p=probs))
+
+    def update(self, state: Iterable[float], action: int) -> None:
+        """Обновить параметры модели одним наблюдением."""
+        state_vec = np.asarray(state)
+        probs = self._softmax(state_vec @ self.W)
+        grad = -np.outer(state_vec, probs)
+        grad[:, action] += state_vec
+        self.W += self.lr * grad

--- a/origo3d/ai/ml/qlearning_npc.py
+++ b/origo3d/ai/ml/qlearning_npc.py
@@ -1,0 +1,40 @@
+"""Простейшая реализация Q-learning для NPC."""
+
+from __future__ import annotations
+
+from typing import Hashable, Iterable, List
+
+import numpy as np
+
+
+class QLearningNPC:
+    """NPC, обучающийся с использованием табличного Q-learning."""
+
+    def __init__(self, actions: Iterable[Hashable], lr: float = 0.1, gamma: float = 0.95, epsilon: float = 0.1) -> None:
+        self.actions: List[Hashable] = list(actions)
+        self.lr = lr
+        self.gamma = gamma
+        self.epsilon = epsilon
+        self.q_table: dict[tuple, np.ndarray] = {}
+
+    def _ensure_state(self, state: Iterable) -> tuple:
+        key = tuple(state)
+        if key not in self.q_table:
+            self.q_table[key] = np.zeros(len(self.actions))
+        return key
+
+    def choose_action(self, state: Iterable) -> Hashable:
+        """Выбрать действие для заданного состояния."""
+        key = self._ensure_state(state)
+        if np.random.rand() < self.epsilon:
+            return np.random.choice(self.actions)
+        return self.actions[int(np.argmax(self.q_table[key]))]
+
+    def update(self, state: Iterable, action: Hashable, reward: float, next_state: Iterable) -> None:
+        """Обновить таблицу Q по наблюдению."""
+        key = self._ensure_state(state)
+        next_key = self._ensure_state(next_state)
+        action_idx = self.actions.index(action)
+        best_next = float(np.max(self.q_table[next_key]))
+        target = reward + self.gamma * best_next
+        self.q_table[key][action_idx] = (1 - self.lr) * self.q_table[key][action_idx] + self.lr * target

--- a/scenes/npc_ml_examples.py
+++ b/scenes/npc_ml_examples.py
@@ -1,0 +1,39 @@
+"""Примеры использования моделей обучения поведения NPC."""
+
+from __future__ import annotations
+
+import numpy as np
+
+from origo3d.ai.ml import LogisticPolicyNPC, QLearningNPC
+
+
+def qlearning_example() -> None:
+    """Демонстрация табличного Q-learning."""
+    actions = ["идти", "стоять"]
+    agent = QLearningNPC(actions)
+    state = [0]
+    for _ in range(10):
+        action = agent.choose_action(state)
+        reward = 1.0 if action == "идти" else 0.0
+        next_state = [state[0] + 1]
+        agent.update(state, action, reward, next_state)
+        state = next_state
+    print("Q-таблица:", agent.q_table)
+
+
+def logistic_example() -> None:
+    """Пример обучения логистической политики."""
+    agent = LogisticPolicyNPC(state_dim=1, num_actions=2)
+    # Учим выбирать действие 1, если значение состояния > 0.5
+    for _ in range(50):
+        s = np.random.rand(1)
+        a = 1 if s[0] > 0.5 else 0
+        agent.update(s, a)
+    test_state = np.array([0.8])
+    chosen = agent.choose_action(test_state)
+    print("Логистическая политика выбрала:", chosen)
+
+
+if __name__ == "__main__":
+    qlearning_example()
+    logistic_example()


### PR DESCRIPTION
## Summary
- реализованы модули `QLearningNPC` и `LogisticPolicyNPC`
- добавлено короткое `__init__` для экспорта моделей
- создана сцена-пример `npc_ml_examples.py`

## Testing
- `python -m py_compile origo3d/ai/ml/qlearning_npc.py origo3d/ai/ml/logistic_policy.py scenes/npc_ml_examples.py`
- `pytest tests/test_core.py::test_load_config -q`
- `pytest -q` *(падает: libGL.so not loaded)*