### PR TITLE
Fix cross-platform pyglet import

### DIFF
--- a/origo3d/core/application.py
+++ b/origo3d/core/application.py
@@ -9,7 +9,7 @@ import time
 
 from devtools.performance_monitor import PerformanceMonitor
 import pyglet
-from pyglet.display import xlib
+from pyglet.window import NoSuchDisplayException
 
 from origo3d.rendering.renderer import Renderer
 
@@ -36,7 +36,7 @@ class Application:
                 vsync=bool(vsync),
                 caption=title,
             )
-        except xlib.NoSuchDisplayException:  # pragma: no cover - depends on env
+        except NoSuchDisplayException:  # pragma: no cover - depends on env
             self.logger.warning("No display available, enabling headless mode")
             pyglet.options["headless"] = True
             self.window = pyglet.window.Window(


### PR DESCRIPTION
## Summary
- избегайте импорта специфичного для Linux модуля "xlib" в "Application"
- вместо этого перехватите "pyglet.window.Исключение NoSuchDisplayException"

## Testing
- `python -m pytest -vv tests origo3d/tests/integration qa` *(fails: ImportError: Library "GL" not found)*