### PR TITLE
Fix grid rendering with pyglet 2.x

### DIFF
--- a/editor/scene_editor.py
+++ b/editor/scene_editor.py
@@ -87,14 +87,42 @@ class SceneEditor(pyglet.window.Window):
 
     def draw_grid(self) -> None:
         step = self.GRID_SPACING
+        modern_api = int(pyglet.version.split(".")[0]) >= 2
+
+        # Pyglet 2.x uses 3D positions and RGBA colors in its default shader.
+        # Provide dummy Z coordinate and full alpha so grid lines render correctly.
         for x in range(0, self.width, step):
-            pyglet.graphics.draw(2, pyglet.gl.GL_LINES,
-                                ("v2f", (x, 0, x, self.height)),
-                                ("c3B", (200, 200, 200) * 2))
+            if modern_api:
+                pyglet.graphics.draw(
+                    2,
+                    pyglet.gl.GL_LINES,
+                    position=("f", (x, 0, 0, x, self.height, 0)),
+                    colors=("Bn", (200, 200, 200, 255) * 2),
+                    tex_coords=("f", (0.0, 0.0, 0.0) * 2),
+                )
+            else:
+                pyglet.graphics.draw(
+                    2,
+                    pyglet.gl.GL_LINES,
+                    ("v2f", (x, 0, x, self.height)),
+                    ("c3B", (200, 200, 200) * 2),
+                )
         for y in range(0, self.height, step):
-            pyglet.graphics.draw(2, pyglet.gl.GL_LINES,
-                                ("v2f", (0, y, self.width, y)),
-                                ("c3B", (200, 200, 200) * 2))
+            if modern_api:
+                pyglet.graphics.draw(
+                    2,
+                    pyglet.gl.GL_LINES,
+                    position=("f", (0, y, 0, self.width, y, 0)),
+                    colors=("Bn", (200, 200, 200, 255) * 2),
+                    tex_coords=("f", (0.0, 0.0, 0.0) * 2),
+                )
+            else:
+                pyglet.graphics.draw(
+                    2,
+                    pyglet.gl.GL_LINES,
+                    ("v2f", (0, y, self.width, y)),
+                    ("c3B", (200, 200, 200) * 2),
+                )
 
     def on_key_press(self, symbol, modifiers):
         ctrl = modifiers & pyglet.window.key.MOD_CTRL


### PR DESCRIPTION
## Summary
- обновлены вершины сетки для шейдера pyglet 2.

## Testing
- `pip install -r requirements.txt`
- `PYGLET_HEADLESS=1 PYTHONPATH=. pytest -q` *(fails: ImportError: Library "GL" not found)*