### PR TITLE
Implement basic CLI runner and commands

### DIFF
--- a/docs/extensibility.md
+++ b/docs/extensibility.md
@@ -20,6 +20,15 @@ def register(cli):
     print("Plugin active")
 ```
 
+После установки плагинов CLI можно запустить так:
+
+```bash
+python -m origo_cli.runner validate-shaders
+```
+
+Загрузчик подключит все модули из `origo_cli/plugins` и передаст CLI объект в их
+функцию `register`, поэтому команда `validate-shaders` станет доступна.
+
 ## Игровые расширения
 
 Внешние расширения располагаются в каталоге `extensions/` в корне проекта либо в

--- a/origo_cli/commands.py
+++ b/origo_cli/commands.py
@@ -1,1 +1,23 @@
-# Auto-generated
+from __future__ import annotations
+
+"""Базовые команды CLI Origo."""
+
+
+def validate_shaders(_args) -> None:
+    """Проверка корректности шейдеров."""
+    print("Validating shaders...")
+
+
+def scene_stats(_args) -> None:
+    """Сбор статистики по сценам."""
+    print("Gathering scene statistics...")
+
+
+def check_textures(_args) -> None:
+    """Проверка текстур на корректность."""
+    print("Checking textures...")
+
+
+def run_ai_tests(_args) -> None:
+    """Запуск тестов ИИ."""
+    print("Running AI tests...")

--- a/origo_cli/plugins/plugin_ai_test_runner.py
+++ b/origo_cli/plugins/plugin_ai_test_runner.py
@@ -1,5 +1,13 @@
 """Пример плагина тестирования AI."""
 
+from .. import commands
+
 
 def register(cli) -> None:
+    if cli is not None:
+        cli.add_command(
+            "run-ai-tests",
+            commands.run_ai_tests,
+            help="Запустить AI тесты",
+        )
     print("AI test runner plugin loaded")

--- a/origo_cli/plugins/plugin_scene_stats.py
+++ b/origo_cli/plugins/plugin_scene_stats.py
@@ -1,5 +1,13 @@
 """Сбор статистики по сцене."""
 
+from .. import commands
+
 
 def register(cli) -> None:
+    if cli is not None:
+        cli.add_command(
+            "scene-stats",
+            commands.scene_stats,
+            help="Вывести статистику сцен",
+        )
     print("Scene stats plugin loaded")

--- a/origo_cli/plugins/plugin_shader_validator.py
+++ b/origo_cli/plugins/plugin_shader_validator.py
@@ -1,5 +1,13 @@
 """Валидация шейдеров перед сборкой."""
 
+from .. import commands
+
 
 def register(cli) -> None:
+    if cli is not None:
+        cli.add_command(
+            "validate-shaders",
+            commands.validate_shaders,
+            help="Проверить шейдеры",
+        )
     print("Shader validator plugin loaded")

--- a/origo_cli/plugins/plugin_texture_checker.py
+++ b/origo_cli/plugins/plugin_texture_checker.py
@@ -1,5 +1,13 @@
 """Проверка корректности текстур."""
 
+from .. import commands
+
 
 def register(cli) -> None:
+    if cli is not None:
+        cli.add_command(
+            "check-textures",
+            commands.check_textures,
+            help="Проверить текстуры",
+        )
     print("Texture checker plugin loaded")

--- a/origo_cli/runner.py
+++ b/origo_cli/runner.py
@@ -1,1 +1,38 @@
-# Auto-generated
+from __future__ import annotations
+
+"""Запуск Origo CLI с загрузкой плагинов."""
+
+from argparse import ArgumentParser
+from typing import Iterable, Callable, Any
+
+from . import load_plugins
+
+
+class CLI:
+    """Простейший контейнер для команд."""
+
+    def __init__(self) -> None:
+        self.parser = ArgumentParser(prog="origo", description="Origo CLI")
+        self.subparsers = self.parser.add_subparsers(dest="command")
+
+    def add_command(self, name: str, func: Callable[[Any], None], help: str = "") -> None:
+        cmd = self.subparsers.add_parser(name, help=help)
+        cmd.set_defaults(func=func)
+
+    def run(self, args: Iterable[str] | None = None) -> None:
+        ns = self.parser.parse_args(args)
+        if hasattr(ns, "func"):
+            ns.func(ns)
+        else:
+            self.parser.print_help()
+
+
+def run_cli(argv: Iterable[str] | None = None) -> None:
+    """Создаёт CLI, загружает плагины и выполняет выбранную команду."""
+    cli = CLI()
+    load_plugins(cli)
+    cli.run(argv)
+
+
+if __name__ == "__main__":
+    run_cli()


### PR DESCRIPTION
## Summary
- implement `run_cli` in `origo_cli.runner`
- add base command implementations
- register commands in builtin plugins
- expand extensibility documentation with CLI example

## Testing
- `pip install -r requirements.txt`
- `pytest -q` *(fails: ImportError: Library "GL" not found)*
- `python -m origo_cli.runner --help`
- `python -m origo_cli.runner validate-shaders`


------
https://chatgpt.com/codex/tasks/task_e_68847dacee9c8332bc3fab112b4e76fe