### PR TITLE
Add ShaderManager with hot reload

### DIFF
--- a/assets/shaders/basic.frag
+++ b/assets/shaders/basic.frag
@@ -1,0 +1,6 @@
+#version 330
+in vec3 v_color;
+out vec4 fragColor;
+void main() {
+    fragColor = vec4(v_color, 1.0);
+}

--- a/assets/shaders/basic.vert
+++ b/assets/shaders/basic.vert
@@ -1,0 +1,9 @@
+#version 330
+uniform mat4 u_mvp;
+in vec3 in_position;
+in vec3 in_color;
+out vec3 v_color;
+void main() {
+    gl_Position = u_mvp * vec4(in_position, 1.0);
+    v_color = in_color;
+}

--- a/origo3d/rendering/backends/directx.py
+++ b/origo3d/rendering/backends/directx.py
@@ -6,13 +6,19 @@ from typing import Tuple
 import logging
 
 from origo3d.rendering.camera import Camera
+from origo3d.resources.shader_manager import ShaderManager
 from origo3d.shaders import get_shader_sources
 
 
 class DirectXBackend:
     """Заглушка реализации DirectX."""
 
-    def __init__(self, width: int = 800, height: int = 600) -> None:
+    def __init__(
+        self,
+        width: int = 800,
+        height: int = 600,
+        shader_manager: ShaderManager | None = None,
+    ) -> None:
         self.logger = logging.getLogger(__name__)
         self.logger.warning("DirectX backend not fully implemented")
         self.clear_color: Tuple[float, float, float, float] = (0.1, 0.1, 0.1, 1.0)

--- a/origo3d/rendering/backends/opengl.py
+++ b/origo3d/rendering/backends/opengl.py
@@ -11,13 +11,18 @@ import moderngl
 
 from origo3d.rendering.camera import Camera
 from origo3d.resources.model_manager import ModelManager
-from origo3d.shaders import get_shader_sources
+from origo3d.resources.shader_manager import ShaderManager
 
 
 class OpenGLBackend:
     """Рендерер OpenGL."""
 
-    def __init__(self, width: int = 800, height: int = 600) -> None:
+    def __init__(
+        self,
+        width: int = 800,
+        height: int = 600,
+        shader_manager: ShaderManager | None = None,
+    ) -> None:
         self.logger = logging.getLogger(__name__)
         try:
             self.ctx = moderngl.create_context()
@@ -29,8 +34,10 @@ class OpenGLBackend:
         self.camera = Camera()
         self.camera.set_aspect(width, height)
         self.model_manager = ModelManager()
-        vert_src, frag_src = get_shader_sources("opengl")
-        self.program = self.ctx.program(vertex_shader=vert_src, fragment_shader=frag_src)
+        self.shader_manager = shader_manager or ShaderManager()
+        vert_path = Path("assets/shaders/basic.vert")
+        frag_path = Path("assets/shaders/basic.frag")
+        self.program = self.shader_manager.load_program(self.ctx, vert_path, frag_path)
         self.logger.info("Shaders compiled successfully")
 
         model_path = Path("assets/models/cube.obj")

--- a/origo3d/rendering/backends/vulkan.py
+++ b/origo3d/rendering/backends/vulkan.py
@@ -6,13 +6,19 @@ from typing import Tuple
 import logging
 
 from origo3d.rendering.camera import Camera
+from origo3d.resources.shader_manager import ShaderManager
 from origo3d.shaders import get_shader_sources
 
 
 class VulkanBackend:
     """Заглушка реализации Vulkan."""
 
-    def __init__(self, width: int = 800, height: int = 600) -> None:
+    def __init__(
+        self,
+        width: int = 800,
+        height: int = 600,
+        shader_manager: ShaderManager | None = None,
+    ) -> None:
         self.logger = logging.getLogger(__name__)
         self.logger.warning("Vulkan backend not fully implemented")
         self.clear_color: Tuple[float, float, float, float] = (0.1, 0.1, 0.1, 1.0)

--- a/origo3d/rendering/renderer.py
+++ b/origo3d/rendering/renderer.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 from typing import Any
 import logging
 
+from hotreload.hotreloader import HotReloader
 from .backends import OpenGLBackend, VulkanBackend, DirectXBackend
+from origo3d.resources.shader_manager import ShaderManager
 
 
 class Renderer:
@@ -17,13 +19,20 @@ class Renderer:
         "directx": DirectXBackend,
     }
 
-    def __init__(self, width: int = 800, height: int = 600, api: str = "opengl") -> None:
+    def __init__(
+        self,
+        width: int = 800,
+        height: int = 600,
+        api: str = "opengl",
+        reloader: HotReloader | None = None,
+    ) -> None:
         self.logger = logging.getLogger(__name__)
         backend_cls = self._BACKENDS.get(api.lower())
         if backend_cls is None:
             raise ValueError(f"Unknown graphics API: {api}")
         self.logger.info("Using %s backend", api)
-        self.backend = backend_cls(width=width, height=height)
+        self.shader_manager = ShaderManager(reloader=reloader)
+        self.backend = backend_cls(width=width, height=height, shader_manager=self.shader_manager)
 
     def __getattr__(self, item: str) -> Any:  # pragma: no cover - delegation
         return getattr(self.backend, item)

--- a/origo3d/resources/shader_manager.py
+++ b/origo3d/resources/shader_manager.py
@@ -1,1 +1,56 @@
-# Manages loaded shaders
+"""Загрузка и кеширование GLSL-шейдеров с поддержкой горячей пересборки."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, Tuple
+import logging
+
+import moderngl
+
+from hotreload.shader_watcher import watch_shader
+from hotreload.hotreloader import HotReloader
+
+
+class ShaderManager:
+    """Компилирует и кеширует программы moderngl."""
+
+    def __init__(self, reloader: HotReloader | None = None) -> None:
+        self.logger = logging.getLogger(__name__)
+        self.reloader = reloader
+        self._programs: Dict[Tuple[int, Path, Path], moderngl.Program] = {}
+
+    def load_program(
+        self,
+        ctx: moderngl.Context,
+        vertex_shader: str | Path,
+        fragment_shader: str | Path,
+    ) -> moderngl.Program:
+        """Загрузить и скомпилировать программу или вернуть из кеша."""
+        vert_path = Path(vertex_shader).resolve()
+        frag_path = Path(fragment_shader).resolve()
+        key = (id(ctx), vert_path, frag_path)
+        if key in self._programs:
+            return self._programs[key]
+
+        program = self._compile(ctx, vert_path, frag_path)
+        self._programs[key] = program
+
+        if self.reloader:
+            watch_shader(self.reloader, vert_path, lambda _: self._reload(key, ctx, vert_path, frag_path))
+            watch_shader(self.reloader, frag_path, lambda _: self._reload(key, ctx, vert_path, frag_path))
+
+        return program
+
+    def _compile(self, ctx: moderngl.Context, vert_path: Path, frag_path: Path) -> moderngl.Program:
+        vert_src = vert_path.read_text(encoding="utf-8")
+        frag_src = frag_path.read_text(encoding="utf-8")
+        return ctx.program(vertex_shader=vert_src, fragment_shader=frag_src)
+
+    def _reload(self, key: Tuple[int, Path, Path], ctx: moderngl.Context, vert: Path, frag: Path) -> None:
+        try:
+            program = self._compile(ctx, vert, frag)
+            self._programs[key] = program
+            self.logger.info("Shader recompiled: %s %s", vert.name, frag.name)
+        except Exception as exc:  # pragma: no cover - depends on env
+            self.logger.error("Failed to recompile shader: %s", exc)

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -4,10 +4,12 @@ from __future__ import annotations
 
 from pathlib import Path
 import sys
+import os
 
 ROOT = Path(__file__).resolve().parents[1]
 if str(ROOT) not in sys.path:
     sys.path.insert(0, str(ROOT))
+os.environ.setdefault("PYGLET_HEADLESS", "True")
 
 from origo3d.core.application import Application
 from runtime import env_settings

--- a/tests/test_shader_manager.py
+++ b/tests/test_shader_manager.py
@@ -1,0 +1,17 @@
+import moderngl
+from origo3d.resources.shader_manager import ShaderManager
+
+
+def test_shader_caching(tmp_path):
+    try:
+        ctx = moderngl.create_standalone_context(backend="egl")
+    except Exception:
+        ctx = moderngl.create_standalone_context()
+    vert = tmp_path / "test.vert"
+    frag = tmp_path / "test.frag"
+    vert.write_text("#version 330\nvoid main(){}")
+    frag.write_text("#version 330\nvoid main(){}")
+    manager = ShaderManager()
+    prog1 = manager.load_program(ctx, vert, frag)
+    prog2 = manager.load_program(ctx, vert, frag)
+    assert prog1 is prog2


### PR DESCRIPTION
## Summary
- реализуем кэширование шейдеров и горячую перезагрузку в ShaderManager
- используем ShaderManager из рендерера и серверной части GL
- разрешаем серверным частям принимать ShaderManager
- добавляем базовые источники шейдеров в assets
- исправлены тесты для запуска без головы и проверки кэширования шейдеров

## Testing
- `pip install -r requirements.txt`
- `PYTHONPATH=. pytest -q`