### PR TITLE
Добавлены UI-тесты с pyautogui

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -16,11 +16,11 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r requirements.txt
-          pip install pytest pytest-cov
+          pip install pytest pytest-cov pyautogui
       - name: Run unit and integration tests
         run: |
           mkdir -p reports
-          python -m pytest -vv tests origo3d/tests/integration qa \
+          xvfb-run -a python -m pytest -vv tests origo3d/tests/integration qa ui_tests \
             --junitxml=reports/tests.xml \
             --cov=. --cov-report=xml:reports/coverage.xml
       - name: Upload test reports

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,3 +8,4 @@ Pillow==11.3.0
 pyglm==2.8.2
 watchdog==6.0.0
 psutil==5.9.8
+pyautogui==0.9.54

--- a/ui_tests/test_main_menu.py
+++ b/ui_tests/test_main_menu.py
@@ -1,1 +1,26 @@
-# Auto-generated
+import os
+import subprocess
+import sys
+import time
+
+import pytest
+
+# UI тесты требуют pyautogui для эмуляции ввода
+pyautogui = pytest.importorskip("pyautogui")
+
+
+@pytest.mark.skipif("DISPLAY" not in os.environ, reason="Требуется доступ к X-серверу")
+def test_open_editor_main_menu():
+    """Проверяем, что главное окно редактора запускается и принимает ввод."""
+    env = os.environ.copy()
+    env.pop("PYGLET_HEADLESS", None)  # гарантируем запуск с графикой
+    proc = subprocess.Popen([sys.executable, "editor/scene_editor.py"], env=env)
+    try:
+        time.sleep(2)
+        pyautogui.press("g")  # пример ввода: переключение сетки
+        time.sleep(1)
+        assert proc.poll() is None, "Редактор завершился преждевременно"
+    finally:
+        proc.terminate()
+        proc.wait(timeout=5)
+


### PR DESCRIPTION
## Summary
- реализован `ui_tests/test_main_menu.py` для проверки запуска редактора
- добавлена установка `pyautogui` и запуск ui-тестов через `xvfb` в CI
- обновлены зависимости проекта

## Testing
- `xvfb-run -a pytest ui_tests/test_main_menu.py -vv`
- `xvfb-run -a pytest -vv` *(ошибка из-за отсутствующих библиотек)*