### PR TITLE
Поддержка конфигов env и новые тесты

### DIFF
--- a/qa/test_integration_settings.py
+++ b/qa/test_integration_settings.py
@@ -14,7 +14,62 @@ def test_load_custom_config(tmp_path, monkeypatch):
 
     monkeypatch.setattr(env_settings, "_BASE_CONFIG", base_cfg)
     monkeypatch.setattr(env_settings, "_CONFIG_DIR", cfg_dir)
+    monkeypatch.setattr(env_settings, "_ENV_DIR", cfg_dir / "env")
+    env_settings._settings = {}
 
     settings = env_settings.load()
     assert settings["graphics"]["vsync"] is False
     assert "extra" in settings
+
+
+def test_env_multiple_files(tmp_path, monkeypatch):
+    base_cfg = tmp_path / "config.yaml"
+    base_cfg.write_text("graphics:\n  vsync: false\n")
+
+    cfg_dir = tmp_path / "configs"
+    env_dir = cfg_dir / "env"
+    env_dir.mkdir(parents=True)
+    (env_dir / "dev.yaml").write_text("DEBUG: 1\n")
+    (env_dir / "local.yaml").write_text("CACHE: 0\n")
+
+    monkeypatch.setattr(env_settings, "_BASE_CONFIG", base_cfg)
+    monkeypatch.setattr(env_settings, "_CONFIG_DIR", cfg_dir)
+    monkeypatch.setattr(env_settings, "_ENV_DIR", env_dir)
+    env_settings._settings = {}
+
+    settings = env_settings.load()
+    assert settings["env"]["dev"]["DEBUG"] == 1
+    assert settings["env"]["local"]["CACHE"] == 0
+
+
+def test_missing_base_config(tmp_path, monkeypatch):
+    base_cfg = tmp_path / "config.yaml"  # do not create
+
+    cfg_dir = tmp_path / "configs"
+    cfg_dir.mkdir()
+    (cfg_dir / "graphics.yaml").write_text("api: opengl\n")
+
+    monkeypatch.setattr(env_settings, "_BASE_CONFIG", base_cfg)
+    monkeypatch.setattr(env_settings, "_CONFIG_DIR", cfg_dir)
+    monkeypatch.setattr(env_settings, "_ENV_DIR", cfg_dir / "env")
+    env_settings._settings = {}
+
+    settings = env_settings.load()
+    assert settings.get("graphics", {}).get("api") == "opengl"
+
+
+def test_invalid_yaml(tmp_path, monkeypatch):
+    base_cfg = tmp_path / "config.yaml"
+    base_cfg.write_text("graphics: [1, 2]\n")
+
+    cfg_dir = tmp_path / "configs"
+    cfg_dir.mkdir()
+    (cfg_dir / "bad.yaml").write_text("foo: [1, 2\n")
+
+    monkeypatch.setattr(env_settings, "_BASE_CONFIG", base_cfg)
+    monkeypatch.setattr(env_settings, "_CONFIG_DIR", cfg_dir)
+    monkeypatch.setattr(env_settings, "_ENV_DIR", cfg_dir / "env")
+    env_settings._settings = {}
+
+    settings = env_settings.load()
+    assert settings.get("bad", {}) == {}

--- a/runtime/env_settings.py
+++ b/runtime/env_settings.py
@@ -17,6 +17,7 @@ import yaml
 
 _BASE_CONFIG = Path("config.yaml")
 _CONFIG_DIR = Path("configs")
+_ENV_DIR = _CONFIG_DIR / "env"
 
 _settings: Dict[str, Any] = {}
 
@@ -25,8 +26,11 @@ def _load_yaml(file: Path) -> Dict[str, Any]:
     """Return contents of a YAML file or an empty dict if it does not exist."""
     if not file.exists():
         return {}
-    with file.open("r", encoding="utf-8") as f:
-        return yaml.safe_load(f) or {}
+    try:
+        with file.open("r", encoding="utf-8") as f:
+            return yaml.safe_load(f) or {}
+    except yaml.YAMLError:
+        return {}
 
 
 def load() -> Dict[str, Any]:
@@ -41,6 +45,14 @@ def load() -> Dict[str, Any]:
     if _CONFIG_DIR.exists():
         for path in _CONFIG_DIR.glob("*.yaml"):
             data[path.stem] = _load_yaml(path)
+
+    # Load environment variables from configs/env directory
+    env_data: Dict[str, Any] = {}
+    if _ENV_DIR.exists():
+        for path in _ENV_DIR.glob("*.yaml"):
+            env_data[path.stem] = _load_yaml(path)
+        if env_data:
+            data["env"] = env_data
 
     _settings = data
     return _settings


### PR DESCRIPTION
## Summary
- загружаем файлы из `configs/env/`
- игнорируем ошибочный YAML
- добавляем тесты для нескольких env-файлов
- покрываем отсутствие `config.yaml` и некорректный YAML

## Testing
- `pytest qa/test_integration_settings.py -q`

------
https://chatgpt.com/codex/tasks/task_e_68848a2b3db88332bd9e38057d7a3249