### PR TITLE
Добавить сбор статистики падений

### DIFF
--- a/telemetry/crash_frequency.py
+++ b/telemetry/crash_frequency.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+import json
+from collections import Counter
+from pathlib import Path
+
+
+def collect_crash_stats(log_path: str | Path = "telemetry/events.log") -> Counter:
+    """Подсчитывает количество падений по причинам.
+
+    Возвращает Counter, где ключ -- причина падения (поле ``reason``),
+    а значение -- число таких событий.
+    Если файл отсутствует, возвращается пустой Counter.
+    """
+    path = Path(log_path)
+    stats: Counter[str] = Counter()
+    if not path.exists():
+        return stats
+    with path.open(encoding="utf-8") as fh:
+        for line in fh:
+            try:
+                event = json.loads(line)
+            except json.JSONDecodeError:
+                continue
+            if event.get("event_type") != "crash":
+                continue
+            reason = str(event.get("reason", "unknown"))
+            stats[reason] += 1
+    return stats
+
+
+def main(log_path: str = "telemetry/events.log") -> None:
+    stats = collect_crash_stats(log_path)
+    print("== Статистика падений ==")
+    for reason, count in stats.items():
+        print(f"{reason}: {count}")
+
+
+if __name__ == "__main__":  # pragma: no cover
+    main()

--- a/tests/test_crash_frequency.py
+++ b/tests/test_crash_frequency.py
@@ -1,0 +1,25 @@
+from pathlib import Path
+import json
+import sys
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from telemetry.crash_frequency import collect_crash_stats
+
+
+def test_collect_crash_stats(tmp_path: Path) -> None:
+    log = tmp_path / "events.log"
+    events = [
+        {"event_type": "crash", "reason": "segfault"},
+        {"event_type": "crash", "reason": "overflow"},
+        {"event_type": "crash", "reason": "segfault"},
+        {"event_type": "info"},
+    ]
+    log.write_text("\n".join(json.dumps(e) for e in events), encoding="utf-8")
+
+    stats = collect_crash_stats(log)
+    assert stats["segfault"] == 2
+    assert stats["overflow"] == 1
+


### PR DESCRIPTION
## Summary
- добавить `collect_crash_stats` для подсчёта падений из `events.log`
- прописать `main()` в `telemetry/crash_frequency.py`
- покрыть функцию тестом `test_crash_frequency.py`

## Testing
- `pytest tests/test_crash_frequency.py tests/test_event_logger.py tests/test_crash_heatmap.py -q`